### PR TITLE
Revert jekyll-scholar bibtex filters (#381)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -162,10 +162,13 @@ scholar:
   source: /_bibliography/
   bibliography: papers.bib
   bibliography_template: bib
+  # Note: if you have latex math in your bibtex, the latex filter
+  # preprocessing may conflict with MathJAX if the latter is enabled.
+  # See https://github.com/alshedivat/al-folio/issues/357.
+  bibtex_filters: [latex, smallcaps, superscript]
 
   replace_strings: true
   join_strings: true
-  bibtex_filters:
 
   details_dir: bibliography
   details_layout: bibtex.html


### PR DESCRIPTION
* Revert "Fix latex rendering issue in the bibliography entries (#358)"

This reverts commit e328dc6abea53a3cb5cd9cf146766d2abe73cfd8.

* Update mathjax version to 3.2.0

* Add bibtex_filters explicitly to _config.yml